### PR TITLE
workaround initial node count issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,9 @@ resource "google_container_cluster" "domino_cluster" {
   # separately managed node pools. So we create the smallest possible default
   # node pool and immediately delete it.
   remove_default_node_pool = true
-  initial_node_count       = 1
+
+  # Workaround for https://github.com/terraform-providers/terraform-provider-google/issues/3385
+  initial_node_count = max(1, var.compute_nodes_min) + max(0, var.gpu_nodes_min) + var.platform_nodes_max
 
   network    = google_compute_network.vpc_network.self_link
   subnetwork = google_compute_subnetwork.default.self_link

--- a/variables.tf
+++ b/variables.tf
@@ -172,7 +172,7 @@ variable "allow_local_ip_access" {
 
 variable "platform_nodes_max" {
   type    = number
-  default = 5
+  default = 3
 }
 
 variable "platform_nodes_min" {


### PR DESCRIPTION
After node pools are added, the cluster begins to scale-up and can cause inaccessibility to the k8s master URL.

Workaround from https://github.com/terraform-providers/terraform-provider-google/issues/3385.

Also sets platform node pool max to something more similar to other production deployments.