### PR TITLE
switch gpu node pool from google-beta back to regular provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,6 @@ resource "google_kms_crypto_key" "crypto_key" {
 }
 
 resource "google_container_node_pool" "gpu" {
-  provider = google-beta
   name     = "gpu"
   location = google_container_cluster.domino_cluster.location
   cluster  = google_container_cluster.domino_cluster.name
@@ -329,10 +328,6 @@ resource "google_container_node_pool" "gpu" {
 
     disk_size_gb    = var.gpu_nodes_ssd_gb
     local_ssd_count = 1
-
-    workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
-    }
   }
 
   management {

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,7 @@ variable "gpu_nodes_ssd_gb" {
   type    = number
   default = 400
 }
+
 variable "location" {
   type        = string
   default     = "us-west1-b"


### PR DESCRIPTION
Potential fix for NodePool delete issues.

https://github.com/terraform-providers/terraform-provider-google/issues/930 seems to imply that each provider has a mutex lock so having one node pool on a different provider could cause parallel ops when destroying a cluster.