### PR TITLE
switch default DNS zone to eng-platform-dev.d.t

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,8 +45,8 @@ variable "google_dns_managed_zone" {
     dns_name = string
   })
   default = {
-    name     = "domino-tech"
-    dns_name = "domino-eng-platform-dev.domino.tech."
+    name     = "eng-platform-dev"
+    dns_name = "eng-platform-dev.domino.tech."
   }
   description = "Cloud DNS zone"
 }


### PR DESCRIPTION
Fleetcommand strips `domino-` from URLs by default (for subaccounts like domino-deploys-kappa -> deploys-kappa.domino.tech), so this new DNS name matches with other defaults.