### PR TITLE
pin google provider to avoid cluster provisioning error in 3.29.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,11 +24,13 @@ locals {
 }
 
 provider "google" {
+  version = "~> 3.20, != 3.29.0"
   project = var.project
   region  = local.region
 }
 
 provider "google-beta" {
+  version = "~> 3.20, != 3.29.0"
   project = var.project
   region  = local.region
 }


### PR DESCRIPTION
Issue: terraform-providers/terraform-provider-google#6744
Fixed appears to be in GoogleCloudPlatform/magic-modules#3732